### PR TITLE
Use multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,21 @@
-FROM golang:1.10
+FROM golang:alpine AS builder
 LABEL MAINTAINER="Salih Çiftçi"
 
 WORKDIR /go/src/liman
 COPY . .
 
-RUN go get -d -v ./... && \
-    go install -v ./... && \
-    curl -sSL https://get.docker.com/ | sh
+RUN apk add -U --no-cache git && \
+    go get -d -v ./... && \
+    go install -v ./...
+
+
+FROM alpine:3.8
+
+COPY --from=builder /go/bin/liman /liman
+COPY --from=builder /go/src/liman/public /public
+COPY --from=builder /go/src/liman/templates /templates
+
+RUN apk add -U --no-cache ca-certificates docker
 
 EXPOSE 8080
-CMD ["liman"]
+CMD /liman


### PR DESCRIPTION
#11
Reduced the size to 172mb.

```
$ docker images --format "{{ .Repository }} {{ .Size }}" | grep liman
liman 172MB
```